### PR TITLE
training.py - pass all eval_metric information to evals_result

### DIFF
--- a/python-package/xgboost/training.py
+++ b/python-package/xgboost/training.py
@@ -56,7 +56,7 @@ def train(params, dtrain, num_boost_round=10, evals=(), obj=None, feval=None,
         else:
             evals_name = [d[1] for d in evals]
             evals_result.clear()
-            evals_result.update({key: [] for key in evals_name})
+            evals_result.update({key: {} for key in evals_name})
 
     if not early_stopping_rounds:
         for i in range(num_boost_round):
@@ -71,9 +71,18 @@ def train(params, dtrain, num_boost_round=10, evals=(), obj=None, feval=None,
                 if verbose_eval:
                     sys.stderr.write(msg + '\n')
                 if evals_result is not None:
-                    res = re.findall(":-?([0-9.]+).", msg)
-                    for key, val in zip(evals_name, res):
-                        evals_result[key].append(val)
+                    res = re.findall("([0-9a-zA-Z@]+[-]*):-?([0-9.]+).", msg)
+                    for key in evals_name:
+                        evals_idx =  evals_name.index(key)
+                        res_per_eval = len(res) / len(evals_name)
+                        for r in range(res_per_eval):
+                            res_item = res[(evals_idx*res_per_eval) + r]
+                            res_key = res_item[0]
+                            res_val = res_item[1]                           
+                            if res_key in evals_result[key]:
+                                evals_result[key][res_key].append(res_val)
+                            else:
+                                evals_result[key][res_key] = [res_val]
         return bst
 
     else:
@@ -119,9 +128,18 @@ def train(params, dtrain, num_boost_round=10, evals=(), obj=None, feval=None,
                 sys.stderr.write(msg + '\n')
 
             if evals_result is not None:
-                res = re.findall(":-?([0-9.]+).", msg)
-                for key, val in zip(evals_name, res):
-                    evals_result[key].append(val)
+                res = re.findall("([0-9a-zA-Z@]+[-]*):-?([0-9.]+).", msg)
+                for key in evals_name:
+                    evals_idx =  evals_name.index(key)
+                    res_per_eval = len(res) / len(evals_name)
+                    for r in range(res_per_eval):
+                        res_item = res[(evals_idx*res_per_eval) + r]
+                        res_key = res_item[0]
+                        res_val = res_item[1]                           
+                        if res_key in evals_result[key]:
+                            evals_result[key][res_key].append(res_val)
+                        else:
+                            evals_result[key][res_key] = [res_val]
 
             score = float(msg.rsplit(':', 1)[1])
             if (maximize_score and score > best_score) or \


### PR DESCRIPTION
Made changes to training.py to make sure all eval_metric information get passed to evals_result. Previous version lost and mislabeled data in evals_result when using more than one eval_metric.

Structure of eval_metric is now:

```
eval_metric[evals][eval_metric] = list of metrics
```

Example:

``` python
import xgboost as xgb

dtrain = xgb.DMatrix('../data/agaricus.txt.train', silent=True)
dtest = xgb.DMatrix('../data/agaricus.txt.test', silent=True)

param = [('max_depth', 2), ('objective', 'binary:logistic'), ('bst:eta', 0.01), ('eval_metric', 'logloss'), ('eval_metric', 'error')]

watchlist  = [(dtest,'eval'), (dtrain,'train')]
num_round = 3
evals_result = {}
bst = xgb.train(param, dtrain, num_round, watchlist, evals_result=evals_result)

print('Access logloss metric directly from eval:')
print(evals_result['eval']['logloss'])

print('')

print('Access metrics through a loop:')
for e_name, e_mtrs in evals_result.items():
    print('- {}'.format(e_name))
    for e_mtr_name, e_mtr_vals in e_mtrs.items():
        print('   - {}'.format(e_mtr_name))
        print('      - {}'.format(e_mtr_vals))

print('')

print('Access complete dict:')
print(evals_result)
```

Prints:

```
Access logloss metric directly from eval:
['0.684877', '0.676767', '0.668817']

Access metrics through a loop:
- train
   - logloss
      - ['0.684954', '0.676917', '0.669036']
   - error
      - ['0.04652', '0.04652', '0.04652']
- eval
   - logloss
      - ['0.684877', '0.676767', '0.668817']
   - error
      - ['0.042831', '0.042831', '0.042831']

Access complete dict:
{'train': {'logloss': ['0.684954', '0.676917', '0.669036'], 'error': ['0.04652', '0.04652', '0.04652']}, 'eval': {'logloss': ['0.684877', '0.676767', '0.668817'], 'error': ['0.042831', '0.042831', '0.042831']}}
```
